### PR TITLE
Add support for vim/viml Markdown fenced code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,17 @@
         "language": "vim-snippet",
         "scopeName": "source.vim-snippet",
         "path": "./syntaxes/snippet.tmLanguage.json"
+      },
+      {
+        "language": "viml-markdown",
+        "scopeName": "markdown.viml.codeblock",
+        "path": "./syntaxes/codeblock.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.viml": "viml"
+        }
       }
     ],
     "languages": [
@@ -106,6 +117,9 @@
           ".snippets"
         ],
         "configuration": "./syntaxes/snippet.language-configuration.json"
+      },
+      {
+        "id": "viml-markdown"
       }
     ]
   },

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -1,0 +1,45 @@
+{
+  "fileTypes": [],
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+    {
+      "include": "#viml-code-block"
+    }
+  ],
+  "repository": {
+    "viml-code-block": {
+      "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(vim|viml)(\\s+[^`~]*)?$)",
+      "name": "markup.fenced_code.block.markdown",
+      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+      "beginCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        },
+        "4": {
+          "name": "fenced_code.block.language.markdown"
+        },
+        "5": {
+          "name": "fenced_code.block.language.attributes.markdown"
+        }
+      },
+      "endCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "contentName": "meta.embedded.block.viml",
+          "patterns": [
+            {
+              "include": "source.viml"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "scopeName": "markdown.viml.codeblock"
+}


### PR DESCRIPTION
I added some code to support embedding VimL fenced code blocks in Markdown files following

https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example

Please, feel free to modify anything you don't like and add it to the extension if you find it useful.. I have my *vim* configuration in a Markdown file so having syntax highlighting is quite useful.