### PR TITLE
Modify activationEvents

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "workspaceContains:**/*.exrc",
     "workspaceContains:**/_vimrc",
     "workspaceContains:**/vimrc",
-    "onLanguage:plaintext"
+    "workspaceContains:**/.*txt"
   ],
   "main": "./out/extension.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -131,7 +131,11 @@
     ]
   },
   "activationEvents": [
-    "onStartupFinished"
+    "onLanguage:viml",
+    "onLanguage:vim-help",
+    "onLanguage:vim-snippet",
+    "onLanguage:vim-markdown"
+
   ],
   "main": "./out/extension.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -131,10 +131,14 @@
     ]
   },
   "activationEvents": [
-    "onLanguage:viml",
-    "onLanguage:vim-help",
-    "onLanguage:vim-snippet",
-    "onLanguage:vim-markdown"
+    "workspaceContains:**/*.vim",
+    "workspaceContains:**/*.vimrc",
+    "workspaceContains:**/*.gvim",
+    "workspaceContains:**/*.ideavim",
+    "workspaceContains:**/*.exrc",
+    "workspaceContains:**/_vimrc",
+    "workspaceContains:**/vimrc",
+    "onLanguage:txt"
   ],
   "main": "./out/extension.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
     "onLanguage:vim-help",
     "onLanguage:vim-snippet",
     "onLanguage:vim-markdown"
-
   ],
   "main": "./out/extension.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "workspaceContains:**/*.exrc",
     "workspaceContains:**/_vimrc",
     "workspaceContains:**/vimrc",
-    "onLanguage:txt"
+    "onLanguage:plaintext"
   ],
   "main": "./out/extension.js",
   "dependencies": {


### PR DESCRIPTION
I changed the way the extension gets launched. At this moment it launches when vscode is opened, I changed so it will be only activated when you open a file with one of the following identifiers:
- viml
- vim-help
- vim-snippet
- vim-markdown

This way the extension is only launched when you need it.