### PR TITLE
chore: remove the vim-markdown language

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
         "path": "./syntaxes/vroom.tmLanguage.json"
       },
       {
-        "language": "vim-markdown",
         "scopeName": "markdown.vim.codeblock",
         "path": "./syntaxes/codeblock.json",
         "injectTo": [
@@ -131,9 +130,6 @@
         "configuration": "./syntaxes/snippet.language-configuration.json"
       },
       {
-        "id": "vim-markdown"
-      },
-      {
         "id": "vroom",
         "aliases": [
           "Vroom"
@@ -149,7 +145,6 @@
     "onLanguage:viml",
     "onLanguage:vim-help",
     "onLanguage:vim-snippet",
-    "onLanguage:vim-markdown",
     "onLanguage:vroom",
     "workspaceContains:**/.*txt"
   ],


### PR DESCRIPTION
This is only used for the viml injection in markdown code blocks. However, no language is needed for this, only the scope name. All defined languages show up in the VSCode language selector.

See https://github.com/microsoft/vscode/issues/207406